### PR TITLE
Use discriminated unions for verificationMethods

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -19,6 +19,7 @@ export default tseslint.config(
     },
     rules: {
       "@typescript-eslint/no-confusing-void-expression": "off",
+      "@typescript-eslint/no-deprecated": "off",
       "@typescript-eslint/no-empty-object-type": [
         "warn",
         {

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
   "scripts": {
     "build": "tsdown",
     "check": "bun run format:check && bun run lint && bun run typecheck && bun test",
-    "clean": "git clean -fdX dist node_modules/.cache",
+    "clean": "git clean -xdf dist node_modules/.cache",
     "fix": "bun run format && bun run lint:fix",
     "format": "prettier --write .",
     "format:check": "prettier --check .",

--- a/src/constants/did.ts
+++ b/src/constants/did.ts
@@ -1,6 +1,9 @@
-import type { VerificationMethodType } from "../types"
+import type {
+  LegacyVerificationMethodType,
+  VerificationMethodType
+} from "../types"
 
-export const verificationMethodTypes: VerificationMethodType[] = [
+export const legacyVerificationMethodTypes: LegacyVerificationMethodType[] = [
   "JsonWebKey2020",
   "Ed25519VerificationKey2020",
   "Ed25519VerificationKey2018",
@@ -9,6 +12,11 @@ export const verificationMethodTypes: VerificationMethodType[] = [
   "EcdsaSecp256k1VerificationKey2019",
   "EcdsaSecp256r1VerificationKey2019",
   "RsaVerificationKey2018"
+]
+
+export const verificationMethodTypes: VerificationMethodType[] = [
+  "JsonWebKey",
+  "Multikey"
 ]
 
 export const didRegex = /^did:[a-z0-9]+:[a-zA-Z0-9.\-_:%]*[a-zA-Z0-9.\-_]$/

--- a/src/types/did/did.ts
+++ b/src/types/did/did.ts
@@ -24,10 +24,10 @@ export type Did<
 export type DidUrl = Did
 
 /**
- * Verification method type.
- * @see {@link https://www.w3.org/TR/did-spec-registries/#verification-method-types}
+ * Outdated verification method types.
+ * @deprecated use {@link VerificationMethodType} instead
  */
-export type VerificationMethodType =
+export type LegacyVerificationMethodType =
   | "JsonWebKey2020"
   | "Ed25519VerificationKey2020"
   | "Ed25519VerificationKey2018"
@@ -38,28 +38,51 @@ export type VerificationMethodType =
   | "RsaVerificationKey2018"
 
 /**
+ * Verification method type.
+ * @see {@link https://www.w3.org/2025/credentials/vcdi/vocab/v2/vocabulary.html#verificationMethod}
+ */
+export type VerificationMethodType = "JsonWebKey" | "Multikey"
+
+/**
  * Verification method.
  * @see {@link https://www.w3.org/TR/did-core/#verification-methods}
  */
-export interface VerificationMethod {
+interface VerificationMethodBase {
   /** A string that conforms to the rules in 3.2 DID URL Syntax. */
   id: DidUrl
 
-  /** The verification method type. */
-  type: VerificationMethodType
-
   /** A string that conforms to the rules in 3.1 DID Syntax. */
   controller: Did
+}
 
+export interface VerificationMethodJsonWebKey extends VerificationMethodBase {
+  type: "JsonWebKey"
   /** A map representing a JSON Web Key that conforms to [RFC7517]. */
-  publicKeyJwk?: unknown
+  publicKeyJwk: unknown
+}
 
+export interface VerificationMethodMultikey extends VerificationMethodBase {
+  type: "Multikey"
   /** A string that conforms to a multibase encoded public key. */
-  publicKeyMultibase?: string
+  publicKeyMultibase: string
+}
 
+export interface VerificationMethodLegacy extends VerificationMethodBase {
+  type: LegacyVerificationMethodType
+  publicKeyMultibase?: string
+  publicKeyJwk?: unknown
   /** @deprecated usa {@link publicKeyMultibase} or {@link publicKeyJwk} instead */
   publicKeyBase58?: string
 }
+
+/**
+ * Verification method.
+ * @see {@link https://www.w3.org/TR/did-core/#verification-methods}
+ */
+export type VerificationMethod =
+  | VerificationMethodJsonWebKey
+  | VerificationMethodMultikey
+  | VerificationMethodLegacy
 
 export interface ServiceEndpointMap {
   [key: string]: string | string[] | Uri | ServiceEndpointMap

--- a/test/did.test.ts
+++ b/test/did.test.ts
@@ -1,8 +1,6 @@
 import { test, expect, describe } from "bun:test"
 import * as valibot from "../src/valibot"
 import * as zod from "../src/zod"
-
-// Import fixtures
 import didKeyValid from "./fixtures/did/did-key-valid.json"
 import didWebValid from "./fixtures/did/did-web-valid.json"
 import documentValid from "./fixtures/did/document-valid.json"
@@ -138,7 +136,7 @@ describe("did", () => {
       test("valid verification method", () => {
         const validVerificationMethod = {
           id: "did:example:123456789abcdefghi#keys-1",
-          type: "JsonWebKey2020",
+          type: "JsonWebKey",
           controller: "did:example:123456789abcdefghi",
           publicKeyJwk: {
             kty: "EC",
@@ -155,30 +153,53 @@ describe("did", () => {
         )
       })
 
-      test("different verification method types", () => {
-        const methodTypes = [
-          "JsonWebKey2020",
-          "Ed25519VerificationKey2020",
-          "Ed25519VerificationKey2018",
-          "X25519KeyAgreementKey2020",
-          "X25519KeyAgreementKey2019",
-          "EcdsaSecp256k1VerificationKey2019",
-          "EcdsaSecp256r1VerificationKey2019",
-          "RsaVerificationKey2018"
-        ]
-
-        for (const type of methodTypes) {
-          const verificationMethod = {
-            id: "did:example:123456789abcdefghi#keys-1",
-            type,
-            controller: "did:example:123456789abcdefghi",
-            publicKeyMultibase: "zQmWvQxTqbG2Z9HPJgG57jjwR2X9GrEJjQAC"
-          }
-
-          expect(verificationMethod).toMatchSchema(
-            schemas.VerificationMethodSchema
-          )
+      test("multikey verification method", () => {
+        const verificationMethod = {
+          id: "did:example:123456789abcdefghi#keys-1",
+          type: "Multikey",
+          controller: "did:example:123456789abcdefghi",
+          publicKeyMultibase: "zQmWvQxTqbG2Z9HPJgG57jjwR2X9GrEJjQAC"
         }
+
+        expect(verificationMethod).toMatchSchema(
+          schemas.VerificationMethodSchema
+        )
+      })
+
+      test("json web key verification method", () => {
+        const verificationMethod = {
+          id: "did:example:123456789abcdefghi#keys-1",
+          type: "JsonWebKey",
+          controller: "did:example:123456789abcdefghi",
+          publicKeyJwk: {
+            kty: "EC",
+            crv: "P-256",
+            x: "MKBCTNIcKUSDii11ySs3526iDZ8AiTo7Tu6KPAqv7D4",
+            y: "4Etl6SRW2YiLUrN5vfvVHuhp7x8PxltmWWlbbM4IFyM"
+          }
+        }
+
+        expect(verificationMethod).toMatchSchema(
+          schemas.VerificationMethodSchema
+        )
+      })
+
+      test("legacy verification method", () => {
+        const verificationMethod = {
+          id: "did:example:123456789abcdefghi#keys-1",
+          type: "JsonWebKey2020",
+          controller: "did:example:123456789abcdefghi",
+          publicKeyJwk: {
+            kty: "EC",
+            crv: "P-256",
+            x: "MKBCTNIcKUSDii11ySs3526iDZ8AiTo7Tu6KPAqv7D4",
+            y: "4Etl6SRW2YiLUrN5vfvVHuhp7x8PxltmWWlbbM4IFyM"
+          }
+        }
+
+        expect(verificationMethod).toMatchSchema(
+          schemas.VerificationMethodSchema
+        )
       })
 
       test("with publicKeyBase58", () => {
@@ -241,7 +262,7 @@ describe("did", () => {
           verificationMethod: [
             {
               id: "did:example:123456789abcdefghi#keys-1",
-              type: "JsonWebKey2020",
+              type: "JsonWebKey",
               controller: "did:example:123456789abcdefghi",
               publicKeyJwk: {
                 kty: "EC",

--- a/test/fixtures/did/document-valid.json
+++ b/test/fixtures/did/document-valid.json
@@ -4,7 +4,7 @@
   "verificationMethod": [
     {
       "id": "did:example:123456789abcdefghi#keys-1",
-      "type": "JsonWebKey2020",
+      "type": "JsonWebKey",
       "controller": "did:example:123456789abcdefghi",
       "publicKeyJwk": {
         "kty": "OKP",


### PR DESCRIPTION
Based on the verificationMethod type, we could use either publicKeyJwk
or publicKeyMultibase.

With this, all verificationMethod types outside of `JsonWebKey` and
`Multikey` are marked as deprecated, but still supported.
