### PR TITLE
fix: correct typos in package.json keyword and CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 
 ### Patch Changes
 
-- 97f1594: Update isDidWithMethod to accpet method as first argument
+- 97f1594: Update isDidWithMethod to accept method as first argument
 
 ## 0.1.5
 

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "verifiable-presentation",
     "status-list",
     "status-list-2021",
-    "bistring",
+    "bitstring",
     "bitstring-status",
     "bitstring-status-list"
   ],


### PR DESCRIPTION
## Summary

Two typo fixes:

### 1. Fix keyword typo in `package.json`

`"bistring"` → `"bitstring"`  misspelled keyword reduces npm discoverability for users searching for bitstring-related packages.

### 2. Fix typo in `CHANGELOG.md`

`"accpet"` → `"accept"` in the v0.1.6 patch notes describing the `isDidWithMethod` parameter change.